### PR TITLE
Typo fixed: <b> should be <p>

### DIFF
--- a/Complete/bundle.js
+++ b/Complete/bundle.js
@@ -212,7 +212,7 @@
 	        Word.run(function (context) {
 
 	            const blankParagraph = context.document.body.paragraphs.getLast().insertParagraph("", "After");
-	            blankParagraph.insertHtml('<p style="font-family: verdana;">Inserted HTML.</b></p><p>Another paragraph</p>', "End");
+	            blankParagraph.insertHtml('<p style="font-family: verdana;">Inserted HTML.</p><p>Another paragraph</p>', "End");
 
 	            return context.sync();
 	        }).catch(function (error) {


### PR DESCRIPTION
Fixed a typo in HTML element name in file Complete/bundle.js